### PR TITLE
画像投稿時にDropzoneが使えるよう実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -171,6 +171,27 @@ footer {
   display: none;
 }
 
-// .dropzone .dz-preview .dz-remove {
-//   display: none;
-// }
+.dropzone .dz-preview .dz-image {
+  width: 100px;
+  height: 100px;
+}
+
+#change-form {
+  color: #717a8f;
+}
+
+#post-dropzone {
+  min-height: 182px;
+  position: relative;
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.dz-button {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -170,3 +170,7 @@ footer {
 .dz-progress {
   display: none;
 }
+
+// .dropzone .dz-preview .dz-remove {
+//   display: none;
+// }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,11 +16,13 @@
 
 @import "bootstrap/scss/bootstrap";
 
-$fa-font-path: '@fortawesome/fontawesome-free/webfonts';
+$fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 @import "@fortawesome/fontawesome-free/scss/regular";
 @import "@fortawesome/fontawesome-free/scss/solid";
 @import "@fortawesome/fontawesome-free/scss/brands";
+
+@import "dropzone/dist/dropzone";
 
 body {
   padding-top: 56px;
@@ -59,7 +61,7 @@ footer {
 
   &:hover {
     color: #717a8f;
-    text-decoration: none
+    text-decoration: none;
   }
 }
 
@@ -163,4 +165,8 @@ footer {
       transform: rotate(-35deg);
     }
   }
+}
+
+.dz-progress {
+  display: none;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -67,3 +67,7 @@
 .post-modal-content {
   text-align: left;
 }
+
+#change-form {
+  color: #717a8f;
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -29,7 +29,6 @@
   margin-right: auto;
   margin-left: auto;
   margin-top: 48px;
-  text-align: center;
 }
 
 .post-index {
@@ -68,6 +67,7 @@
   text-align: left;
 }
 
-#change-form {
-  color: #717a8f;
+.edit-images {
+  text-align: center;
+  margin-bottom: 16px;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,8 +15,14 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params)
-    @post.save!
-    redirect_to root_path
+    if params[:file].present?
+      @post.images = params[:file].values
+      @post.save!
+      render json: {}
+    else
+      @post.save!
+      redirect_to root_path
+    end
   end
 
   def edit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,9 +30,12 @@ class PostsController < ApplicationController
 
   def update
     remove_images(params[:indexes])
-    add_more_images(post_params[:images])
+    add_more_images(params[:file]&.values)
     @post.update!(post_params.except(:images))
-    redirect_to root_path
+    respond_to do |format|
+      format.html { redirect_to root_path }
+      format.json { render json: {} }
+    end
   end
 
   def destroy
@@ -79,6 +82,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content, { images: [] })
+    params.require(:post).permit(:title, :content)
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,6 +18,7 @@ document.addEventListener("turbolinks:load", () => {
   const editForm = document.getElementById("edit-form");
   const editBtns = document.querySelectorAll(".edit-btn");
   const postForm = document.getElementById("post-form");
+  const changeForm = document.getElementById("change-form");
 
   editBtns.forEach((editBtn) => {
     editBtn.addEventListener("click", () => {
@@ -28,6 +29,13 @@ document.addEventListener("turbolinks:load", () => {
       );
     });
   });
+
+  if (changeForm) {
+    changeForm.addEventListener("click", () => {
+      postForm.classList.toggle("d-none");
+      editForm.classList.toggle("d-none");
+    });
+  }
 
   if (postForm) {
     document.getElementById("post-dropzone").classList.add("dropzone");

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -42,6 +42,11 @@ document.addEventListener("turbolinks:load", () => {
     document.getElementById("post-btn").addEventListener("click", (e) => {
       e.preventDefault();
       e.stopPropagation();
+      document
+        .querySelectorAll(".dropzone .dz-preview .dz-remove")
+        .forEach((el) => {
+          el.style.display = "none";
+        });
       postDropzone.processQueue();
     });
 
@@ -49,6 +54,10 @@ document.addEventListener("turbolinks:load", () => {
       document.querySelectorAll("#post-form input").forEach((e) => {
         formData.append(e.name, e.value);
       });
+    });
+
+    postDropzone.on("complete", () => {
+      location.href = `/posts`;
     });
   }
 });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,10 +32,23 @@ document.addEventListener("turbolinks:load", () => {
 
     var postDropzone = new Dropzone("#post-dropzone", {
       url: postForm.action,
+      autoDiscover: false,
       autoProcessQueue: false,
       addRemoveLinks: true,
-      uploadMultiple: true,
       dictRemoveFile: "削除",
+      uploadMultiple: true,
+    });
+
+    document.getElementById("post-btn").addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      postDropzone.processQueue();
+    });
+
+    postDropzone.on("sendingmultiple", function (data, xhr, formData) {
+      document.querySelectorAll("#post-form input").forEach((e) => {
+        formData.append(e.name, e.value);
+      });
     });
   }
 });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,7 +20,7 @@ document.addEventListener("turbolinks:load", () => {
   editBtns.forEach((editBtn) => {
     editBtn.addEventListener("click", () => {
       editBtn.parentNode.classList.add("d-none");
-      editForm.insertAdjacentHTML(
+      postForm.insertAdjacentHTML(
         "afterbegin",
         `<input type="hidden" name="indexes[]" value="${editBtn.id}">`
       );
@@ -40,14 +40,16 @@ document.addEventListener("turbolinks:load", () => {
     });
 
     document.getElementById("post-btn").addEventListener("click", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      document
-        .querySelectorAll(".dropzone .dz-preview .dz-remove")
-        .forEach((el) => {
-          el.style.display = "none";
-        });
-      postDropzone.processQueue();
+      if (postDropzone.getQueuedFiles().length > 0) {
+        e.preventDefault();
+        e.stopPropagation();
+        document
+          .querySelectorAll(".dropzone .dz-preview .dz-remove")
+          .forEach((el) => {
+            el.style.display = "none";
+          });
+        postDropzone.processQueue();
+      }
     });
 
     postDropzone.on("sendingmultiple", function (data, xhr, formData) {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -52,6 +52,7 @@ document.addEventListener("turbolinks:load", () => {
       dictFileTooBig: `ファイルサイズは最大${maxFilesize}MBです`,
       maxFiles: maxFiles,
       dictMaxFilesExceeded: `ファイルの最大数は${maxFiles}です`,
+      dictDefaultMessage: "Click here to upload images",
     });
 
     document.getElementById("post-btn").addEventListener("click", (e) => {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,25 +3,42 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-require("@rails/ujs").start()
-require("turbolinks").start()
-require("@rails/activestorage").start()
-require("channels")
-require("bootstrap/dist/js/bootstrap")
-require("@fortawesome/fontawesome-free/js/all")
+require("@rails/ujs").start();
+require("turbolinks").start();
+require("@rails/activestorage").start();
+require("channels");
+require("bootstrap/dist/js/bootstrap");
+require("@fortawesome/fontawesome-free/js/all");
+
+const Dropzone = require("dropzone/dist/dropzone");
 
 document.addEventListener("turbolinks:load", () => {
-  const editForm = document.getElementById('edit-form')
-  const editBtns = document.querySelectorAll('.edit-btn')
+  const editForm = document.getElementById("edit-form");
+  const editBtns = document.querySelectorAll(".edit-btn");
+  const postForm = document.getElementById("post-form");
 
   editBtns.forEach((editBtn) => {
     editBtn.addEventListener("click", () => {
-      editBtn.parentNode.classList.add("d-none")
-      editForm.insertAdjacentHTML('afterbegin', `<input type="hidden" name="indexes[]" value="${editBtn.id}">`)
-    })
-  })
-})
+      editBtn.parentNode.classList.add("d-none");
+      editForm.insertAdjacentHTML(
+        "afterbegin",
+        `<input type="hidden" name="indexes[]" value="${editBtn.id}">`
+      );
+    });
+  });
 
+  if (postForm) {
+    document.getElementById("post-dropzone").classList.add("dropzone");
+
+    var postDropzone = new Dropzone("#post-dropzone", {
+      url: postForm.action,
+      autoProcessQueue: false,
+      addRemoveLinks: true,
+      uploadMultiple: true,
+      dictRemoveFile: "削除",
+    });
+  }
+});
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,8 @@ require("bootstrap/dist/js/bootstrap");
 require("@fortawesome/fontawesome-free/js/all");
 
 const Dropzone = require("dropzone/dist/dropzone");
+const maxFiles = 10;
+const maxFilesize = 30;
 
 document.addEventListener("turbolinks:load", () => {
   const editForm = document.getElementById("edit-form");
@@ -37,6 +39,11 @@ document.addEventListener("turbolinks:load", () => {
       addRemoveLinks: true,
       dictRemoveFile: "削除",
       uploadMultiple: true,
+      parallelUploads: maxFiles,
+      maxFilesize: maxFilesize,
+      dictFileTooBig: `ファイルサイズは最大${maxFilesize}MBです`,
+      maxFiles: maxFiles,
+      dictMaxFilesExceeded: `ファイルの最大数は${maxFiles}です`,
     });
 
     document.getElementById("post-btn").addEventListener("click", (e) => {
@@ -58,7 +65,7 @@ document.addEventListener("turbolinks:load", () => {
       });
     });
 
-    postDropzone.on("complete", () => {
+    postDropzone.on("success", () => {
       location.href = `/posts`;
     });
   }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -21,7 +21,7 @@
     </div>
     <div id="post-dropzone"></div>
     <div>
-      <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5" %>
+      <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5", id: "post-btn" %>
     </div>
   <% end %>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -7,10 +7,21 @@
     <div>
       <%= form.label :content, "内容" %>
       <%= form.text_area :content, class: "form-control mb-3" %>
-      <p><%= form.file_field :images, multiple: true %></p>
     </div>
     <div>
       <%= form.submit "送信", class: "btn btn-outline-dark mb-5" %>
+    </div>
+  <% end %>
+</div>
+<div class="form-container">
+  <%= form_with model: @post, local: true, id: "post-form" do |form| %>
+    <div class="form-group">
+      <%= form.label :title, "タイトル" %>
+      <%= form.text_field :title, class: "form-control" %>
+    </div>
+    <div id="post-dropzone"></div>
+    <div>
+      <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5" %>
     </div>
   <% end %>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 </div>
 <div class="form-container">
-  <%= form_with model: @post, local: true, id: "post-form" do |form| %>
+  <%= form_with model: @post, local: true, id: "post-form", class: "d-none" do |form| %>
     <div class="form-group">
       <%= form.label :title, "タイトル" %>
       <%= form.text_field :title, class: "form-control" %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,26 +1,27 @@
 <div class="form-container">
   <%= form_with model: @post, local: true, id: "edit-form" do |form| %>
     <div class="form-group">
-      <%= form.label :title, "タイトル" %>
+      <%= form.label :title, "キーワード" %>
       <%= form.text_field :title, class: "form-control" %>
     </div>
     <div>
-      <%= form.label :content, "内容" %>
-      <%= form.text_area :content, class: "form-control mb-3" %>
+      <%= form.label :content, "本文" %>
+      <%= form.text_area :content, class: "form-control mb-3", rows: 7 %>
     </div>
-    <div>
-      <%= form.submit "送信", class: "btn btn-outline-dark mb-5" %>
+    <div class="text-right">
+      <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5" %>
     </div>
   <% end %>
 </div>
 <div class="form-container">
   <%= form_with model: @post, local: true, id: "post-form", class: "d-none" do |form| %>
     <div class="form-group">
-      <%= form.label :title, "タイトル" %>
+      <%= form.label :title, "キーワード" %>
       <%= form.text_field :title, class: "form-control" %>
     </div>
+    <%= form.label :images, "画像" %>
     <div id="post-dropzone"></div>
-    <div>
+    <div class="text-right">
       <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5", id: "post-btn" %>
     </div>
   <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,13 +1,30 @@
 <div class="post-container mb-3">
-  <h1>編集</h1>
-  <%= @post.title %></p>
-<% @post.images.each_with_index do |image, index| %>
-  <div class="edit">
-    <%= image_tag image.url, class: "post-img" %>
-    <div id="<%= index %>" class="edit-btn">
-      <i class="fas fa-times-circle fa-lg"></i>
+  <h1 class="text-center mb-4">編集</h1>
+  <%= form_with model: @post, local: true, id: "post-form" do |form| %>
+    <div class="form-group">
+      <%= form.label :title, "キーワード" %>
+      <%= form.text_field :title, class: "form-control mb-4" %>
     </div>
-  </div>
-<% end %>
+    <% if @post.content.present? %>
+      <div>
+        <%= form.label :content, "本文" %>
+        <%= form.text_area :content, class: "form-control mb-3", rows: 7 %>
+      </div>
+    <% else %>
+      <div class="edit-images">
+        <% @post.images.each_with_index do |image, index| %>
+          <div class="edit">
+            <%= image_tag image.url, class: "post-img" %>
+            <div id="<%= index %>" class="edit-btn">
+              <i class="fas fa-times-circle fa-lg"></i>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <div id="post-dropzone"></div>
+    <% end %>
+    <div class="text-right">
+      <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5", id: "post-btn" %>
+    </div>
+  <% end %>
 </div>
-<%= render 'form' %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -36,14 +36,15 @@
                 </button>
               </div>
               <div class="modal-body">
-                <%# <% binding.pry %>
-                <% post.images.each do |image| %>
-                  <%= image_tag image.url, class: "post-img" %>
+                <% if post.images? %>
+                  <% post.images.each do |image| %>
+                    <%= image_tag image.url, class: "post-img" %>
+                  <% end %>
+                <% else %>
+                  <div class="post-modal-content">
+                    <%= safe_join(post.content&.split("\n"), tag(:br)) %>
+                  </div>
                 <% end %>
-                <div class="post-modal-content">
-                  <%# <%= simple_format(h(post.content)) %>
-                  <%= safe_join(post.content.split("\n"), tag(:br)) %>
-                </div>
               </div>
               <div class="modal-footer">
                 <%= link_to "Edit", edit_post_path(post), class: "btn btn-success" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -42,7 +42,7 @@
                   <% end %>
                 <% else %>
                   <div class="post-modal-content">
-                    <%= safe_join(post.content&.split("\n"), tag(:br)) %>
+                    <%= safe_join(post.content&.split("\n") || [""], tag(:br)) %>
                   </div>
                 <% end %>
               </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,4 @@
 <div class="post-container">
-  <h1>新規投稿</h1>
+  <h1 class="text-center mb-4">新規投稿</h1>
 </div>
 <%= render "form" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,14 @@
 <nav class="navbar header-nav fixed-top">
   <% if user_signed_in? %>
     <%= link_to "LINE BOT", posts_path, class: "navbar-brand" %>
-    <%= link_to new_post_path do %>
-      <i class="far fa-plus-square new-plus fa-lg"></i>
+    <% if request.fullpath == "/posts/new" %>
+      <div id="change-form">
+        <i class="fas fa-random fa-lg"></i>
+      </div>
+    <% else %>
+      <%= link_to new_post_path do %>
+        <i class="far fa-plus-square new-plus fa-lg"></i>
+      <% end %>
     <% end %>
   <% else %>
     <span class="navbar-brand">LINE BOT</span>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.5.2",
+    "dropzone": "^5.7.2",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,6 +2586,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dropzone@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/dropzone/-/dropzone-5.7.2.tgz#91bee1572dda515d40901da304bc79dddf309b4c"
+  integrity sha512-m217bJHtf0J1IiKn4Tv6mnu1h5QvQNBnKZ39gma7hzGQhIZMxYq1vYEHs4AVd4ThFwmALys+52NAOD4zdLTG4w==
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"


### PR DESCRIPTION
## 内容

- Dropzoneを導入し、詳細を設定
- 画像と文字で処理を分け、モーダルで上手く表示できるよう調整
- 画像の追加編集をDropzoneでできるよう修正
- Dropzoneで投稿する画像にバリデーションを追加
- 本番環境で画像がない場合にエラーが出ないよう修正
- 新規投稿ページ右上ボタンでフォームが切り替わるよう実装
- 新規投稿と編集ページのフォームとスタイルを調整