### PR TITLE
キーワードが重複しないようにバリデーションを追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,6 +11,7 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @keywords = current_user.posts.pluck(:title)
   end
 
   def create
@@ -26,6 +27,7 @@ class PostsController < ApplicationController
   end
 
   def edit
+    @keywords = current_user.posts.pluck(:title) - [@post[:title]]
   end
 
   def update

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,6 +27,13 @@ document.addEventListener("turbolinks:load", () => {
   const postTextbtn = document.getElementById("post-text-btn");
   const editDropbtn = document.getElementById("edit-drop-btn");
   const editTextbtn = document.getElementById("edit-text-btn");
+  const keywords = document.getElementById('keywords')
+  let keywordList
+
+  // 新規投稿 & 編集
+  if (keywords) {
+    keywordList = JSON.parse(keywords.dataset.keywords)
+  }
 
   // 新規投稿＆編集（Dropzoneあり）
   if (postDropzoneId) {
@@ -62,10 +69,22 @@ document.addEventListener("turbolinks:load", () => {
   if (formContent) {
     [textFormtitle, formContent].forEach((form) => {
       form.addEventListener("keyup", () => {
-        if (postTextbtn) {
-          postTextbtn.disabled = !(textFormtitle.value && formContent.value);
+        const keyword = document.getElementById('post-text-title').value
+
+        const isKeywordDuplicate = keywordList.some(el => el == keyword)
+        const textFormTitleEmpty = !textFormtitle.value
+        const textContentTitleEmpty = !formContent.value
+
+        if (isKeywordDuplicate) {
+          textFormtitle.classList.add('is-invalid')
         } else {
-          editTextbtn.disabled = !(textFormtitle.value && formContent.value);
+          textFormtitle.classList.remove('is-invalid')
+        }
+
+        if (postTextbtn) {
+          postTextbtn.disabled = (isKeywordDuplicate || textFormTitleEmpty || textContentTitleEmpty);
+        } else {
+          editTextbtn.disabled = (isKeywordDuplicate || textFormTitleEmpty || textContentTitleEmpty);
         }
       });
     });
@@ -130,7 +149,7 @@ document.addEventListener("turbolinks:load", () => {
     const editValidation = () => {
       const postedEmpty =
         document.querySelectorAll(".edit").length -
-          document.querySelectorAll(".edit-images .d-none").length ==
+        document.querySelectorAll(".edit-images .d-none").length ==
         0;
       const dropEmpty = postDropzone.getQueuedFiles().length == 0;
       const imagesEmpty = postedEmpty && dropEmpty;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -69,8 +69,7 @@ document.addEventListener("turbolinks:load", () => {
   if (formContent) {
     [textFormtitle, formContent].forEach((form) => {
       form.addEventListener("keyup", () => {
-        const keyword = document.getElementById('post-text-title').value
-
+        const keyword = textFormtitle.value
         const isKeywordDuplicate = keywordList.some(el => el == keyword)
         const textFormTitleEmpty = !textFormtitle.value
         const textContentTitleEmpty = !formContent.value
@@ -109,8 +108,19 @@ document.addEventListener("turbolinks:load", () => {
     });
 
     const postValidation = () => {
-      postDropbtn.disabled = !(
-        dropFormtitle.value && postDropzone.getQueuedFiles().length
+      const keyword = dropFormtitle.value
+      const isKeywordDuplicate = keywordList.some(el => el == keyword)
+      const dropFormTitleEmpty = !dropFormtitle.value
+      const dropzoneContentEmpty = postDropzone.getQueuedFiles().length == 0
+
+      if (isKeywordDuplicate) {
+        dropFormtitle.classList.add('is-invalid')
+      } else {
+        dropFormtitle.classList.remove('is-invalid')
+      }
+
+      postDropbtn.disabled = (
+        isKeywordDuplicate || dropFormTitleEmpty || dropzoneContentEmpty
       );
     };
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -157,13 +157,22 @@ document.addEventListener("turbolinks:load", () => {
     });
 
     const editValidation = () => {
+      const keyword = textFormtitle.value
+      const isKeywordDuplicate = keywordList.some(el => el == keyword)
       const postedEmpty =
         document.querySelectorAll(".edit").length -
         document.querySelectorAll(".edit-images .d-none").length ==
         0;
       const dropEmpty = postDropzone.getQueuedFiles().length == 0;
       const imagesEmpty = postedEmpty && dropEmpty;
-      editDropbtn.disabled = !textFormtitle.value || imagesEmpty;
+
+      if (isKeywordDuplicate) {
+        textFormtitle.classList.add('is-invalid')
+      } else {
+        textFormtitle.classList.remove('is-invalid')
+      }
+
+      editDropbtn.disabled = !keyword || imagesEmpty || isKeywordDuplicate;
     };
 
     textFormtitle.addEventListener("keyup", () => editValidation());

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,7 @@ class Post < ApplicationRecord
   belongs_to :user
   mount_uploaders :images, ImageUploader
 
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: { scope: :user_id }
   validate :confirmation_post_form
 
   def confirmation_post_form

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,6 +3,9 @@
     <div class="form-group">
       <%= form.label :title, "キーワード" %>
       <%= form.text_field :title, class: "form-control", id: "post-text-title" %>
+      <div class="invalid-feedback">
+        同じキーワードがすでに存在しています。
+      </div>
     </div>
     <div>
       <%= form.label :content, "本文" %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -21,6 +21,9 @@
     <div class="form-group">
       <%= form.label :title, "キーワード" %>
       <%= form.text_field :title, class: "form-control", id: "post-drop-title" %>
+      <div class="invalid-feedback">
+        同じキーワードがすでに存在しています。
+      </div>
     </div>
     <%= form.label :images, "画像" %>
     <div id="post-dropzone"></div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -3,7 +3,10 @@
   <%= form_with model: @post, local: true, id: "post-form" do |form| %>
     <div class="form-group">
       <%= form.label :title, "キーワード" %>
-      <%= form.text_field :title, class: "form-control mb-4", id: "post-text-title" %>
+      <%= form.text_field :title, class: "form-control", id: "post-text-title" %>
+      <div class="invalid-feedback">
+        同じキーワードがすでに存在しています。
+      </div>
     </div>
     <% if @post.content.present? %>
       <div>
@@ -31,3 +34,4 @@
     <% end %>
   <% end %>
 </div>
+<div id="keywords" data-keywords='<%= @keywords %>'></div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -2,3 +2,4 @@
   <h1 class="text-center mb-4">新規投稿</h1>
 </div>
 <%= render "form" %>
+<div id="keywords" data-keywords='<%= @keywords %>'></div>

--- a/db/migrate/20200915130514_add_index_to_posts.rb
+++ b/db/migrate/20200915130514_add_index_to_posts.rb
@@ -1,0 +1,5 @@
+class AddIndexToPosts < ActiveRecord::Migration[6.0]
+  def change
+    add_index :posts, [:title, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_22_063154) do
+ActiveRecord::Schema.define(version: 2020_09_15_130514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2020_08_22_063154) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.json "images"
+    t.index ["title", "user_id"], name: "index_posts_on_title_and_user_id", unique: true
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
## 内容

- マイグレーションファイルを修正
- postモデルにバリデーションを追加
- 重複するキーワードを判定するためにコントローラーを修正
- キーワードが重複したらボタンを無効化し、エラーメッセージを表示