### PR TITLE
ランダム投稿機能を実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -184,7 +184,7 @@ footer {
   min-height: 182px;
   position: relative;
   text-align: center;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .dz-button {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -71,3 +71,9 @@
   text-align: center;
   margin-bottom: 16px;
 }
+
+.custom-control-label {
+  color: dimgray;
+  font-size: 12px;
+  padding-top: 4px;
+}

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -25,20 +25,41 @@ class LinebotController < ApplicationController
               text: "返すものがないよん(´·ω·`)",
             }
           else
-            image = post.images.sample
             content = post.content
+            images = post.images
+            random_image = images.sample
 
             if content.present?
-              message = {
-                type: "text",
-                text: content,
-              }
-            elsif image.present?
-              message = {
-                type: "image",
-                originalContentUrl: image.url,
-                previewImageUrl: image.url,
-              }
+              if post.random
+                random_content = content.split(/\R{3,}/).sample
+                random_content.slice!(/\A・/)
+
+                message = {
+                  type: "text",
+                  text: random_content,
+                }
+              else
+                message = {
+                  type: "text",
+                  text: content,
+                }
+              end
+            elsif images.present?
+              if post.random
+                message = {
+                  type: "image",
+                  originalContentUrl: random_image.url,
+                  previewImageUrl: random_image.url,
+                }
+              else
+                message = images.map do |image|
+                  {
+                    type: "image",
+                    originalContentUrl: image.url,
+                    previewImageUrl: image.url,
+                  }
+                end
+              end
             end
           end
         end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -16,10 +16,17 @@ class LinebotController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
+          current_user = User.find_by(uid: event["source"]["userId"])
           title = event.message["text"]
-          post = Post.find_by(title: title)
+          post = current_user.posts.find_by(title: title)
+          lists = current_user.posts.pluck(:title).join("\r\n\r\n")
 
-          if post.nil?
+          if Post::KEYWORDS_LIST.include?(title)
+            message = {
+              type: "text",
+              text: lists,
+            }
+          elsif post.nil?
             message = {
               type: "text",
               text: "返すものがないよん(´·ω·`)",

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,9 +17,6 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if params[:file].present?
-      if params[:file].values.length > 5 && !params[:post][:random]
-        redirect_to new_post_path
-      end
       @post.images = params[:file].values
       @post.save!
       render json: {}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,6 +17,9 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if params[:file].present?
+      if params[:file].values.length > 5 && !params[:post][:random]
+        redirect_to new_post_path
+      end
       @post.images = params[:file].values
       @post.save!
       render json: {}
@@ -84,6 +87,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content)
+    params.require(:post).permit(:title, :content, :random)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,7 +11,7 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
-    @keywords = current_user.posts.pluck(:title)
+    @keywords = current_user.posts.pluck(:title) + Post::KEYWORDS_LIST
   end
 
   def create
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
   end
 
   def edit
-    @keywords = current_user.posts.pluck(:title) - [@post[:title]]
+    @keywords = current_user.posts.pluck(:title) - [@post[:title]] + Post::KEYWORDS_LIST
   end
 
   def update

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -29,6 +29,7 @@ document.addEventListener("turbolinks:load", () => {
   const editTextbtn = document.getElementById("edit-text-btn");
   const keywords = document.getElementById('keywords')
   let keywordList
+  const randomBtn = document.getElementById('drop-random')
 
   // 新規投稿 & 編集
   if (keywords) {
@@ -56,7 +57,11 @@ document.addEventListener("turbolinks:load", () => {
 
     postDropzone.on("sendingmultiple", function (data, xhr, formData) {
       document.querySelectorAll("#post-form input").forEach((e) => {
-        formData.append(e.name, e.value);
+        if (e.name == "post[random]") {
+          formData.append(e.name, e.checked)
+        } else {
+          formData.append(e.name, e.value);
+        }
       });
     });
 
@@ -112,6 +117,7 @@ document.addEventListener("turbolinks:load", () => {
       const isKeywordDuplicate = keywordList.some(el => el == keyword)
       const dropFormTitleEmpty = !dropFormtitle.value
       const dropzoneContentEmpty = postDropzone.getQueuedFiles().length == 0
+      const randomInvalid = randomBtn.checked == false && postDropzone.getQueuedFiles().length > 5
 
       if (isKeywordDuplicate) {
         dropFormtitle.classList.add('is-invalid')
@@ -120,7 +126,7 @@ document.addEventListener("turbolinks:load", () => {
       }
 
       postDropbtn.disabled = (
-        isKeywordDuplicate || dropFormTitleEmpty || dropzoneContentEmpty
+        isKeywordDuplicate || dropFormTitleEmpty || dropzoneContentEmpty || randomInvalid
       );
     };
 
@@ -129,6 +135,8 @@ document.addEventListener("turbolinks:load", () => {
     postDropzone.on("addedfiles", () => postValidation());
 
     postDropzone.on("removedfile", () => postValidation());
+
+    randomBtn.addEventListener("change", () => postValidation())
   }
 
   // 編集（画像）

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -116,8 +116,9 @@ document.addEventListener("turbolinks:load", () => {
       const keyword = dropFormtitle.value
       const isKeywordDuplicate = keywordList.some(el => el == keyword)
       const dropFormTitleEmpty = !dropFormtitle.value
-      const dropzoneContentEmpty = postDropzone.getQueuedFiles().length == 0
-      const randomInvalid = randomBtn.checked == false && postDropzone.getQueuedFiles().length > 5
+      const imageNum = postDropzone.getQueuedFiles().length
+      const dropzoneContentEmpty = !imageNum
+      const randomInvalid = !randomBtn.checked && imageNum > 5
 
       if (isKeywordDuplicate) {
         dropFormtitle.classList.add('is-invalid')
@@ -167,12 +168,10 @@ document.addEventListener("turbolinks:load", () => {
     const editValidation = () => {
       const keyword = textFormtitle.value
       const isKeywordDuplicate = keywordList.some(el => el == keyword)
-      const postedEmpty =
-        document.querySelectorAll(".edit").length -
-        document.querySelectorAll(".edit-images .d-none").length ==
-        0;
-      const dropEmpty = postDropzone.getQueuedFiles().length == 0;
-      const imagesEmpty = postedEmpty && dropEmpty;
+      const imageTotalNum = document.querySelectorAll(".edit").length -
+        document.querySelectorAll(".edit-images .d-none").length + postDropzone.getQueuedFiles().length
+      const imagesEmpty = !imageTotalNum
+      const randomInvalid = !randomBtn.checked && imageTotalNum > 5
 
       if (isKeywordDuplicate) {
         textFormtitle.classList.add('is-invalid')
@@ -180,7 +179,7 @@ document.addEventListener("turbolinks:load", () => {
         textFormtitle.classList.remove('is-invalid')
       }
 
-      editDropbtn.disabled = !keyword || imagesEmpty || isKeywordDuplicate;
+      editDropbtn.disabled = !keyword || imagesEmpty || isKeywordDuplicate || randomInvalid
     };
 
     textFormtitle.addEventListener("keyup", () => editValidation());
@@ -192,6 +191,8 @@ document.addEventListener("turbolinks:load", () => {
     editBtns.forEach((editBtn) => {
       editBtn.addEventListener("click", () => editValidation());
     });
+
+    randomBtn.addEventListener("change", () => editValidation())
   }
 });
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,8 +4,15 @@ class Post < ApplicationRecord
 
   validates :title, presence: true, uniqueness: { scope: :user_id }
   validate :confirmation_post_form
+  validate :post_random_images
 
   def confirmation_post_form
     errors.add(:base, "画像または本文が必要です") unless content.present? ^ images?
+  end
+
+  def post_random_images
+    if images.length > 5 && !random
+      errors.add(:base, "全ての画像を送信する場合は5枚以下にして下さい")
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,6 +7,7 @@ class Post < ApplicationRecord
   validates :title, presence: true, uniqueness: { scope: :user_id }
   validate :confirmation_post_form
   validate :post_random_images
+  validate :confirmation_keywords_list
 
   def confirmation_post_form
     errors.add(:base, "画像または本文が必要です") unless content.present? ^ images?
@@ -15,6 +16,12 @@ class Post < ApplicationRecord
   def post_random_images
     if images.length > 5 && !random
       errors.add(:base, "全ての画像を送信する場合は5枚以下にして下さい")
+    end
+  end
+
+  def confirmation_keywords_list
+    if KEYWORDS_LIST.include?(title)
+      errors.add(:base, "タイトルは「#{KEYWORDS_LIST.join(",")}」以外で入力して下さい")
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  KEYWORDS_LIST = %w[リスト].freeze
+
   belongs_to :user
   mount_uploaders :images, ImageUploader
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -9,7 +9,11 @@
     </div>
     <div>
       <%= form.label :content, "本文" %>
-      <%= form.text_area :content, class: "form-control mb-3", rows: 7 %>
+      <%= form.text_area :content, class: "form-control mb-2", rows: 7 %>
+    </div>
+    <div class="custom-control custom-switch">
+      <%= form.check_box :random, class: "custom-control-input", id: "content-random" %>
+      <%= form.label :random, "ランダムで返す", class: "custom-control-label", for: "content-random" %>
     </div>
     <div class="text-right">
       <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5", id: "post-text-btn", disabled: true %>
@@ -27,6 +31,10 @@
     </div>
     <%= form.label :images, "画像" %>
     <div id="post-dropzone"></div>
+    <div class="custom-control custom-switch">
+      <%= form.check_box :random, class: "custom-control-input", id: "drop-random" %>
+      <%= form.label :random, "ランダムで返す", class: "custom-control-label", for: "drop-random" %>
+    </div>
     <div class="text-right">
       <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5", id: "post-drop-btn", disabled: true %>
     </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -11,7 +11,11 @@
     <% if @post.content.present? %>
       <div>
         <%= form.label :content, "本文" %>
-        <%= form.text_area :content, class: "form-control mb-3", rows: 7 %>
+        <%= form.text_area :content, class: "form-control mb-2", rows: 7 %>
+      </div>
+      <div class="custom-control custom-switch">
+        <%= form.check_box :random, class: "custom-control-input", id: "content-random" %>
+        <%= form.label :random, "ランダムで返す", class: "custom-control-label", for: "content-random" %>
       </div>
       <div class="text-right">
         <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5", id: "edit-text-btn" %>
@@ -28,6 +32,10 @@
         <% end %>
       </div>
       <div id="post-dropzone"></div>
+      <div class="custom-control custom-switch">
+        <%= form.check_box :random, class: "custom-control-input", id: "drop-random" %>
+        <%= form.label :random, "ランダムで返す", class: "custom-control-label", for: "drop-random" %>
+      </div>
       <div class="text-right">
         <%= form.submit "送信", class: "btn btn-outline-dark mt-3 mb-5", id: "edit-drop-btn" %>
       </div>


### PR DESCRIPTION
## 内容

- ランダム
  - 新規投稿ページ、編集ページにランダムボタンを追加
  - ボタン無効化の条件にランダムボタンと画像枚数の判定を追加
  - ランダムボタンなしで6枚以上の画像が送信できないようバリデーションを追加
  - 本文や画像をランダムに返信出るようにコントローラーを修正

- リスト
  - LINE側でキーワード一覧が表示できるよう実装
  - postモデルでタイトルのバリデーションを追加